### PR TITLE
Use comment.char = "" to avoid SMILES with # prematurely end the line

### DIFF
--- a/multivariate_wrapper.R
+++ b/multivariate_wrapper.R
@@ -109,20 +109,23 @@ xMN <- t(as.matrix(read.table(argVc["dataMatrix_in"],
                               check.names = FALSE,
                               header = TRUE,
                               row.names = 1,
-                              sep = "\t")))
+                              sep = "\t",
+                              comment.char = "")))
 
 samDF <- read.table(argVc["sampleMetadata_in"],
                     check.names = FALSE,
                     header = TRUE,
                     row.names = 1,
-                    sep = "\t")
+                    sep = "\t",
+                    comment.char = "")
 flgF("identical(rownames(xMN), rownames(samDF))", txtC = "Sample names (or number) in the data matrix (first row) and sample metadata (first column) are not identical; use the 'Check Format' module in the 'Quality Control' section")
 
 varDF <- read.table(argVc["variableMetadata_in"],
                     check.names = FALSE,
                     header = TRUE,
                     row.names = 1,
-                    sep = "\t")
+                    sep = "\t",
+                    comment.char = "")
 flgF("identical(colnames(xMN), rownames(varDF))", txtC = "Variable names (or number) in the data matrix (first column) and sample metadata (first column) are not identical; use the 'Check Format' module in the 'Quality Control' section")
 
 flgF("argVc['respC'] == 'none' || (argVc['respC'] %in% colnames(samDF))",


### PR DESCRIPTION
Hi, one might consider doing that only for the Variable metadata,
but you could also imagine people doing names like "sample #13".
Fixes #1 