### PR TITLE
added selector to dump Rdata

### DIFF
--- a/multivariate_config.xml
+++ b/multivariate_config.xml
@@ -44,6 +44,10 @@
   variableMetadata_out "$variableMetadata_out"
   figure "$figure"
   information "$information"
+
+  #if $save_rdata:
+    ropls_out "$ropls_out"
+  #end if
   ]]></command>
   
   <inputs>
@@ -180,7 +184,8 @@
 	
       </when>
     </conditional>
-    
+    <param name="save_rdata" type="boolean" truevalue="yes" falsevalue="no" checked="false" label="Save RData in your history"
+           help="Save the R ropls::opls object in your history for ad hoc analysis and graphing (outside Galaxy, this requires package 'bioconductor-ropls')"/>
   </inputs>
   
   <outputs>
@@ -188,6 +193,10 @@
     <data name="variableMetadata_out" label="${tool.name}_${variableMetadata_in.name}" format="tabular" ></data>
     <data name="figure" label="${tool.name}_figure.pdf" format="pdf"/>
     <data name="information" label="${tool.name}_information.txt" format="txt"/>
+    <!-- how would an ropls.rdata datatype be added if that were the desired choice here instead?  Specifically, could it be created as part of tool installation? -->
+    <data name="ropls_out" label="${tool.name}_${dataMatrix_in.name}.RData" format="rdata">
+      <filter>save_rdata</filter>
+    </data>
   </outputs>
   
   <tests>


### PR DESCRIPTION
I have observed (as documented in the help) the scores and loadings for two PCs (perhaps the first two components or perhaps the two chosen when running the tool) are added as columns to sampleMetadata and variableMetadata.  At the moment, my experimental analysis requires all of the scores and loadings for each among the "optimal number of components". 

Because (delightfully) multivariate_wrapper.R already has the code to save the RData, all that I needed to do was to modify multivariate_config.xml slightly. For a working copy of this modification, please see

    https://testtoolshed.g2.bx.psu.edu/repository?repository_id=482ff00193d6451d

which I can deprecate once a decision has been reached on this pull request.  Thank you and best regards.
- Art